### PR TITLE
Bananabenana patch 1

### DIFF
--- a/flanker/cluster.py
+++ b/flanker/cluster.py
@@ -3,7 +3,6 @@ import glob
 import tempfile
 import subprocess
 import collections
-
 import pandas as pd
 import networkx as nx
 
@@ -14,22 +13,39 @@ https://github.com/rrwick/Assembly-Dereplicator. The other functions are also ad
 for assembly de-replicator.
 """
 
-def find_all_assemblies():
-    all_assemblies=[]
-    for foldername, subfolders, filenames in os.walk(os.getcwd()):
-        for filename in filenames:
+def find_all_assemblies(output_dir):
+    all_assemblies = []
+    missing_fastas = []
 
-            #might need something more sophisticated than 50
+    # Ensure the output directory exists
+    if not os.path.exists(output_dir):
+        print(f"Warning: Output directory {output_dir} does not exist.")
+        return all_assemblies
 
-            if os.path.getsize(os.path.join(foldername,filename)) > 100:
-                if filename.endswith('flank.fasta'):
-                    all_assemblies.append(filename)
+    # Only search inside the specified output directory
+    for filename in os.listdir(output_dir):
+        file_path = os.path.join(output_dir, filename)
 
+        # Print the file path to check what it's finding
+        print(f"Checking file: {file_path}")
 
-    print('found {:,} files\n'.format(len(all_assemblies)))
+        if os.path.isfile(file_path) and os.path.getsize(file_path) > 100 and filename.endswith('flank.fasta'):
+            try:
+                with open(file_path, 'r') as f:
+                    pass  # Just attempting to open it
+                all_assemblies.append(file_path)
+            except Exception:
+                missing_fastas.append(file_path)
+
+    # Log missing files
+    if missing_fastas:
+        with open("missing_fastas.txt", "a") as log_file:
+            log_file.write("\n".join(missing_fastas) + "\n")
+
+    print(f'Found {len(all_assemblies):,} files in {output_dir}')
+    print(f'Logged {len(missing_fastas)} missing files to missing_fastas.txt')
 
     return all_assemblies
-
 
 def build_mash_sketch(assemblies, threads, temp_dir, sketch_size,kmer_length):
     mash_command = ['mash', 'sketch', '-p', str(threads), '-o', temp_dir + '/mash',
@@ -86,17 +102,12 @@ def flank_scrub():
 
 
 #here we build clusters using mash distances
-def define_clusters(gene,window,threads,threshold,outfile,kmer_length,sketch_size):
-
-
+def define_clusters(gene, window, threads, threshold, outfile, kmer_length, sketch_size):
     with tempfile.TemporaryDirectory() as temp_dir:
-        all_assemblies=find_all_assemblies()
-        mash_sketch = build_mash_sketch(all_assemblies, threads, temp_dir, sketch_size,kmer_length)
+        all_assemblies = find_all_assemblies(outfile)  # Pass the correct directory
+        mash_sketch = build_mash_sketch(all_assemblies, threads, temp_dir, sketch_size, kmer_length)
 
-        pairwise_distances= pairwise_mash_distances(mash_sketch,threads)
+        pairwise_distances = pairwise_mash_distances(mash_sketch, threads)
+        clusters = create_graph_from_distances(pairwise_distances, float(threshold))
 
-
-
-        clusters=create_graph_from_distances(pairwise_distances, float(threshold))
-
-        clusters.to_csv(str(outfile + '_' + gene.strip() + '_' + str(window)),index=False)
+        clusters.to_csv(f"{outfile}_{gene.strip()}_{window}", index=False)

--- a/flanker/flanker.py
+++ b/flanker/flanker.py
@@ -374,8 +374,6 @@ def flank_fasta_file_circ(file, window, gene):
                         #record.seq = record.seq.reverse_complement()
                         if args.flank == 'upstream':
                             x = 'downstream'
-                        elif args.flank =='both':
-                            x = 'both'
                         else:
                             x = 'upstream'
 
@@ -491,8 +489,6 @@ def flank_fasta_file_lin(file, window, gene):
 
                         if args.flank == 'upstream':
                             x = 'downstream'
-                        elif args.flank =='both':
-                            x = 'both'
                         else:
                             x = 'upstream'
 
@@ -544,7 +540,7 @@ def flanker_main():
                         args.outfile,
                         args.kmer_length,
                         args.sketch_size)
-                    cluster.flank_scrub()
+                #     cluster.flank_scrub()
 
             if args.cluster and args.mode == 'mm':
 
@@ -557,7 +553,7 @@ def flanker_main():
                     args.kmer_length,
                     args.sketch_size)
                 log.info("Cleaning up")
-                cluster.flank_scrub()
+                # cluster.flank_scrub()
 
     else:
         for gene in gene_list:
@@ -579,7 +575,7 @@ def flanker_main():
                     args.kmer_length,
                     args.sketch_size)
                 log.info("Cleaning up")
-                cluster.flank_scrub()
+                # cluster.flank_scrub()
 
         if args.cluster and args.mode == 'mm':
             log.info("Performing clustering")
@@ -592,7 +588,7 @@ def flanker_main():
                 args.kmer_length,
                 args.sketch_size)
             log.info("Cleaning up")
-            cluster.flank_scrub()
+            # cluster.flank_scrub()
 
 
 def main():


### PR DESCRIPTION
Introduced a few fixes for issues I had with Flanker. 

Primarily, issues around finding files for the clustering step. So now this will now do a slightly different search for files and also log the 'missing' files.

Additionally, this deals with the --cluster/-cl [issue](https://github.com/wtmatlock/flanker/issues/53) where clustering automatically deletes fasta files generated. Now, this behaviour is just simply commented out and doesn't do this anymore. This means you don't need to run the program multiple times!